### PR TITLE
Improve Android selection, file opening, layout, and startup guidance

### DIFF
--- a/android/app/src/androidTest/java/com/gazboard/app/EditorTest.kt
+++ b/android/app/src/androidTest/java/com/gazboard/app/EditorTest.kt
@@ -198,7 +198,7 @@ class EditorTest {
       } finally { copy.delete() }
     }
   }
-  @Test fun longPressShowsActionsAndHandlesResizeWithThePenChosen() {
+  @Test fun fingerHoldShowsActionsAndEitherPointerResizesWithThePenChosen() {
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
       until(scenario, "!!window.app && !!window.app.store")
       js(scenario, """
@@ -212,15 +212,15 @@ class EditorTest {
                 isPrimary: true, button: 0, buttons: type === 'pointerup' ? 0 : 1, pressure: .5,
                 clientX: r.left + x, clientY: r.top + y }));
             };
-            for (const [device, finger] of [['touch', 'yes'], ['touch', 'no'], ['pen', 'yes']]) {
+            for (const finger of ['yes', 'no']) for (const device of ['touch', 'pen']) {
               app.hideMenus(); app.setTool('pen'); app.settings.inkWithFinger = finger;
               app.store.add({ id: 'hold-note', type: 'note', x: 60, y: 70, w: 150, h: 150,
                 rotation: 0, text: 'Resize me', color: '#ffd94a', font: 'ui', align: 'center' });
               const before = app.store.count;
-              pointer('pointerdown', device, 130, 140);
+              pointer('pointerdown', 'touch', 130, 140);
               await new Promise(resolve => setTimeout(resolve, 520));
               if (!document.querySelector('.pop .menu') || !app.selection.has('hold-note')) throw Error('Hold menu missing: ' + device + finger);
-              pointer('pointerup', device, 130, 140);
+              pointer('pointerup', 'touch', 130, 140);
               const box = app.surface.selectionScreenBox();
               pointer('pointerdown', device, box.x + box.w, box.y + box.h);
               pointer('pointermove', device, box.x + box.w + 35, box.y + box.h + 35);
@@ -235,6 +235,45 @@ class EditorTest {
       """.trimIndent())
       until(scenario, "window.holdTestDone === true || !!window.holdTestError")
       assertEquals("null", js(scenario, "window.holdTestError || null"))
+    }
+  }
+  @Test fun pausedStylusKeepsWritingWithoutSelectingTheNote() {
+    ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+      until(scenario, "!!window.app && !!window.app.store")
+      js(scenario, """
+        (async () => {
+          try {
+            await app.loadBoard({ id: 'stylus-pause-test', name: 'Pause and write', objects: [], pages: [], camera: { x: 0, y: 0, z: 1 } });
+            const canvas = document.getElementById('c');
+            const pointer = (type, x, y) => {
+              const r = canvas.getBoundingClientRect();
+              canvas.dispatchEvent(new PointerEvent(type, { pointerId: 72, pointerType: 'pen', bubbles: true,
+                isPrimary: true, button: 0, buttons: type === 'pointerup' ? 0 : 1, pressure: .5,
+                clientX: r.left + x, clientY: r.top + y }));
+            };
+            app.store.add({ id: 'pause-note', type: 'note', x: 60, y: 70, w: 150, h: 150,
+              rotation: 0, text: 'Write over me', color: '#ffd94a', font: 'ui', align: 'center' });
+            const note = JSON.stringify(app.store.get('pause-note'));
+            for (const tool of ['pen', 'highlighter']) for (const finger of ['yes', 'no']) {
+              app.hideMenus(); app.setSelection([]); app.setTool(tool); app.settings.inkWithFinger = finger;
+              const before = app.store.count;
+              pointer('pointerdown', 130, 140);
+              await new Promise(resolve => setTimeout(resolve, 700));
+              if (document.querySelector('.pop .menu') || app.selection.size) throw Error('Stylus pause selected an object');
+              if (app.interaction.action?.type !== 'draw' || !app.surface.wet) throw Error('Stylus pause lost the stroke');
+              pointer('pointermove', 150, 160);
+              pointer('pointerup', 150, 160);
+              const stroke = app.store.objects.at(-1);
+              if (app.store.count !== before + 1 || stroke.type !== 'stroke' || stroke.tool !== tool || stroke.bbox.w <= 4) throw Error('Writing did not resume: ' + tool + finger);
+              if (app.tool !== tool || app.selection.size || app.surface.wet) throw Error('Writing changed the active tool or selection');
+              if (JSON.stringify(app.store.get('pause-note')) !== note) throw Error('Stylus moved or changed the note');
+            }
+            window.stylusPauseDone = true;
+          } catch (e) { window.stylusPauseError = e.stack; }
+        })();
+      """.trimIndent())
+      until(scenario, "window.stylusPauseDone === true || !!window.stylusPauseError")
+      assertEquals("null", js(scenario, "window.stylusPauseError || null"))
     }
   }
   @Test fun boardStoragePreservesBackgroundImportsAndImages() {

--- a/android/app/src/androidTest/java/com/gazboard/app/EditorTest.kt
+++ b/android/app/src/androidTest/java/com/gazboard/app/EditorTest.kt
@@ -198,7 +198,7 @@ class EditorTest {
       } finally { copy.delete() }
     }
   }
-  @Test fun fingerHoldShowsActionsAndEitherPointerResizesWithThePenChosen() {
+  @Test fun fingerAndStylusHoldShowActionsAndResizeWithThePenChosen() {
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
       until(scenario, "!!window.app && !!window.app.store")
       js(scenario, """
@@ -212,19 +212,20 @@ class EditorTest {
                 isPrimary: true, button: 0, buttons: type === 'pointerup' ? 0 : 1, pressure: .5,
                 clientX: r.left + x, clientY: r.top + y }));
             };
-            for (const finger of ['yes', 'no']) for (const device of ['touch', 'pen']) {
+            for (const finger of ['yes', 'no']) for (const device of ['touch', 'pen']) for (const resizeWith of ['touch', 'pen']) {
               app.hideMenus(); app.setTool('pen'); app.settings.inkWithFinger = finger;
               app.store.add({ id: 'hold-note', type: 'note', x: 60, y: 70, w: 150, h: 150,
                 rotation: 0, text: 'Resize me', color: '#ffd94a', font: 'ui', align: 'center' });
-              const before = app.store.count;
-              pointer('pointerdown', 'touch', 130, 140);
+              const before = app.store.count, undo = app.store.undoStack.length;
+              pointer('pointerdown', device, 130, 140);
               await new Promise(resolve => setTimeout(resolve, 520));
               if (!document.querySelector('.pop .menu') || !app.selection.has('hold-note')) throw Error('Hold menu missing: ' + device + finger);
-              pointer('pointerup', 'touch', 130, 140);
+              pointer('pointerup', device, 130, 140);
+              if (app.store.undoStack.length !== undo) throw Error('Holding left an undo entry');
               const box = app.surface.selectionScreenBox();
-              pointer('pointerdown', device, box.x + box.w, box.y + box.h);
-              pointer('pointermove', device, box.x + box.w + 35, box.y + box.h + 35);
-              pointer('pointerup', device, box.x + box.w + 35, box.y + box.h + 35);
+              pointer('pointerdown', resizeWith, box.x + box.w, box.y + box.h);
+              pointer('pointermove', resizeWith, box.x + box.w + 35, box.y + box.h + 35);
+              pointer('pointerup', resizeWith, box.x + box.w + 35, box.y + box.h + 35);
               if (app.store.get('hold-note').w <= 150 || app.tool !== 'pen') throw Error('Resize did not work with the pen chosen');
               if (app.store.count !== before) throw Error('Resizing left ink');
               app.store.remove(['hold-note']); app.setSelection([]);
@@ -237,7 +238,7 @@ class EditorTest {
       assertEquals("null", js(scenario, "window.holdTestError || null"))
     }
   }
-  @Test fun pausedStylusKeepsWritingWithoutSelectingTheNote() {
+  @Test fun movingStylusCancelsHoldSelectionAndKeepsWriting() {
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
       until(scenario, "!!window.app && !!window.app.store")
       js(scenario, """
@@ -258,10 +259,10 @@ class EditorTest {
               app.hideMenus(); app.setSelection([]); app.setTool(tool); app.settings.inkWithFinger = finger;
               const before = app.store.count;
               pointer('pointerdown', 130, 140);
+              pointer('pointermove', 150, 160);
               await new Promise(resolve => setTimeout(resolve, 700));
               if (document.querySelector('.pop .menu') || app.selection.size) throw Error('Stylus pause selected an object');
               if (app.interaction.action?.type !== 'draw' || !app.surface.wet) throw Error('Stylus pause lost the stroke');
-              pointer('pointermove', 150, 160);
               pointer('pointerup', 150, 160);
               const stroke = app.store.objects.at(-1);
               if (app.store.count !== before + 1 || stroke.type !== 'stroke' || stroke.tool !== tool || stroke.bbox.w <= 4) throw Error('Writing did not resume: ' + tool + finger);

--- a/android/app/src/androidTest/java/com/gazboard/app/EditorTest.kt
+++ b/android/app/src/androidTest/java/com/gazboard/app/EditorTest.kt
@@ -198,7 +198,7 @@ class EditorTest {
       } finally { copy.delete() }
     }
   }
-  @Test fun fingerAndStylusHoldShowActionsAndResizeWithThePenChosen() {
+  @Test fun holdingShowsOnlyQuickActionsUntilMoreIsTapped() {
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
       until(scenario, "!!window.app && !!window.app.store")
       js(scenario, """
@@ -219,9 +219,18 @@ class EditorTest {
               const before = app.store.count, undo = app.store.undoStack.length;
               pointer('pointerdown', device, 130, 140);
               await new Promise(resolve => setTimeout(resolve, 520));
-              if (!document.querySelector('.pop .menu') || !app.selection.has('hold-note')) throw Error('Hold menu missing: ' + device + finger);
-              pointer('pointerup', device, 130, 140);
-              if (app.store.undoStack.length !== undo) throw Error('Holding left an undo entry');
+              if (document.querySelector('.pop .menu') || !app.selection.has('hold-note') || !document.querySelector('#ctxbar.show')) throw Error('Hold must show only quick actions: ' + device + finger);
+              pointer('pointermove', device, 150, 160);
+              pointer('pointerup', device, 150, 160);
+              if (app.store.get('hold-note').x <= 60) throw Error('Holding did not allow dragging');
+              canvas.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+              if (document.querySelector('.pop .menu')) throw Error('Release or native contextmenu opened expanded actions');
+              const more = document.querySelector('#ctxbar [title="More actions"]');
+              if (!more) throw Error('Quick actions must offer More');
+              more.click();
+              if (!document.querySelector('.pop .menu') || !app.selection.has('hold-note')) throw Error('More did not expand actions for the selection');
+              app.hideMenus();
+              if (app.store.undoStack.length !== undo + 1) throw Error('Hold and drag should record only the move');
               const box = app.surface.selectionScreenBox();
               pointer('pointerdown', resizeWith, box.x + box.w, box.y + box.h);
               pointer('pointermove', resizeWith, box.x + box.w + 35, box.y + box.h + 35);
@@ -230,6 +239,14 @@ class EditorTest {
               if (app.store.count !== before) throw Error('Resizing left ink');
               app.store.remove(['hold-note']); app.setSelection([]);
             }
+            app.store.add({ id: 'locked-note', type: 'note', x: 60, y: 70, w: 150, h: 150,
+              rotation: 0, locked: true, text: 'Locked', color: '#ffd94a', font: 'ui', align: 'center' });
+            pointer('pointerdown', 'pen', 130, 140);
+            await new Promise(resolve => setTimeout(resolve, 520));
+            pointer('pointerup', 'pen', 130, 140);
+            if (document.querySelector('.pop .menu')) throw Error('Locked hold opened expanded actions');
+            document.querySelector('#ctxbar [title="More actions"]').click();
+            if (!document.querySelector('.pop .menu')?.textContent.includes('Unlock')) throw Error('Locked actions must remain available through More');
             window.holdTestDone = true;
           } catch (e) { window.holdTestError = e.stack; }
         })();

--- a/android/app/src/androidTest/java/com/gazboard/app/FileOpenTest.kt
+++ b/android/app/src/androidTest/java/com/gazboard/app/FileOpenTest.kt
@@ -1,0 +1,116 @@
+package com.gazboard.app
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.core.content.FileProvider
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.gazboard.sync.*
+import java.io.File
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FileOpenTest {
+  private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+  private fun js(scenario: ActivityScenario<MainActivity>, code: String): String {
+    val result = CompletableFuture<String>()
+    scenario.onActivity { it.web.evaluateJavascript(code) { value -> result.complete(value ?: "null") } }
+    return result.get(10, TimeUnit.SECONDS)
+  }
+  private fun until(scenario: ActivityScenario<MainActivity>, expression: String) {
+    val start = System.currentTimeMillis()
+    while (System.currentTimeMillis() - start < 30000) {
+      if (js(scenario, expression) == "true") return
+      Thread.sleep(100)
+    }
+    fail("Editor did not satisfy: $expression; " + js(scenario, "document.body.innerText.slice(-1600)"))
+  }
+  private fun view(uri: Uri, mime: String) = Intent(Intent.ACTION_VIEW).apply {
+    setDataAndType(uri, mime)
+    setPackage(context.packageName)
+    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+  }
+
+  @Test fun fileManagerCanResolveBoardsWithGenericOrSpecificTypes() {
+    val uri = Uri.parse("content://example.documents/document/12345")
+    for (mime in listOf("application/octet-stream", "application/x-gazboard", "application/json")) {
+      val matches = context.packageManager.queryIntentActivities(view(uri, mime), PackageManager.MATCH_DEFAULT_ONLY)
+      assertTrue("GazBoard must be offered for $mime", matches.any { it.activityInfo.name == MainActivity::class.java.name })
+    }
+    val web = view(Uri.parse("https://example.com/file.bin"), "application/octet-stream")
+    assertTrue("The binary fallback is only for granted local content", context.packageManager
+      .queryIntentActivities(web, PackageManager.MATCH_DEFAULT_ONLY).isEmpty())
+  }
+
+  @Test fun tappingAFileOpensItOnLaunchAndAgainWhileRunning() {
+    val app = context.applicationContext as GazBoardApplication
+    val firstId = Protocol.deviceId()
+    val secondId = Protocol.deviceId()
+    val folder = File(context.cacheDir, "exports").apply { mkdirs() }
+    val first = File(folder, "$firstId.bin")
+    val second = File(folder, "$secondId.bin")
+    fun board(id: String, name: String) = json("id" to id, "name" to name, "schema" to 2,
+      "pages" to emptyList<Any>(), "objects" to listOf(json("id" to "note-$id", "type" to "note",
+        "x" to 60, "y" to 70, "w" to 150, "h" to 150, "text" to "বাংলা board", "color" to "#ffd94a"))).toString()
+    first.writeText(board(firstId, "File manager first"))
+    second.writeText(board(secondId, "File manager second"))
+    try {
+      // The URI has no board extension. Its DISPLAY_NAME does, as with many
+      // document providers, including files extracted from a ZIP archive.
+      val firstUri = FileProvider.getUriForFile(context, context.packageName + ".files", first, "Lesson.chapter.বাংলা.gazboard")
+      val secondUri = FileProvider.getUriForFile(context, context.packageName + ".files", second, "Second board.openboard")
+      ActivityScenario.launch<MainActivity>(view(firstUri, "application/octet-stream")).use { scenario ->
+        until(scenario, "window.app?.store?.doc.id === '$firstId' && app.store.count === 1")
+        assertEquals("\"File manager first\"", js(scenario, "app.store.doc.name"))
+        js(scenario, "app.settings.autosave = false; app.store.rename('Keep these edits');")
+        // Exercise Android's actual singleTop delivery, not a direct call to
+        // onNewIntent or the JavaScript import handler.
+        scenario.onActivity { it.startActivity(view(secondUri, "application/octet-stream").addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)) }
+        until(scenario, "window.app?.store?.doc.id === '$secondId' && app.store.count === 1")
+        assertEquals("\"File manager second\"", js(scenario, "app.store.doc.name"))
+        assertEquals("Keep these edits", app.storage.load(firstId)?.str("name"))
+        assertEquals("true", js(scenario, "app.store.objects[0].text === 'বাংলা board'"))
+        js(scenario, "app.settings.autosave = true;")
+      }
+    } finally {
+      first.delete(); second.delete()
+      app.storage.remove(firstId); app.storage.remove(secondId)
+    }
+  }
+
+  @Test fun androidStartupHintUsesTouchControlsAndAppearsOnce() {
+    ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+      until(scenario, "!!window.app?.store")
+      js(scenario, """
+        (async () => {
+          const settings = structuredClone(app.settings);
+          try {
+            app.settings.updateCheck = false;
+            for (const mode of ['yes', 'no']) {
+              document.getElementById('hints').innerHTML = '';
+              app.settings.hintsSeen = {}; app.settings.inkWithFinger = mode;
+              await app.startUpdateFlow();
+              const text = document.getElementById('hints').textContent;
+              if (!text.includes('two fingers') || !text.includes('pinch') || !text.includes('stylus')) throw Error('Missing Android gestures');
+              if (text.includes('middle mouse') || text.includes('Space')) throw Error('Desktop hint leaked into Android');
+              if (!text.includes(mode === 'yes' ? 'finger draws' : 'finger moves')) throw Error('Hint disagrees with finger settings');
+              await app.startUpdateFlow();
+              if (document.querySelectorAll('#hints .hint').length !== 1) throw Error('Startup hint repeated');
+            }
+            window.androidHintDone = true;
+          } catch (e) { window.androidHintError = e.stack; }
+          finally { app.settings = settings; app.saveSettings(); document.getElementById('hints').innerHTML = ''; }
+        })();
+      """.trimIndent())
+      until(scenario, "window.androidHintDone || !!window.androidHintError")
+      assertEquals("null", js(scenario, "window.androidHintError || null"))
+    }
+  }
+}

--- a/android/app/src/androidTest/java/com/gazboard/app/InsetsTest.kt
+++ b/android/app/src/androidTest/java/com/gazboard/app/InsetsTest.kt
@@ -1,6 +1,8 @@
 package com.gazboard.app
 
 import android.graphics.Bitmap
+import android.os.SystemClock
+import android.view.MotionEvent
 import android.content.pm.ActivityInfo
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
@@ -115,23 +117,55 @@ class InsetsTest {
       checkGap(before)
       assertEquals("Native padding already protects the page", 0.0, before.getValue("padding").jsonPrimitive.double, 1.0)
       screenshot("android-toolbar.png")
-      js(scenario, "document.getElementById('boardTitle').focus();")
+      until("Editor window did not gain focus") {
+        var focused = false
+        scenario.onActivity { focused = it.web.hasWindowFocus() }
+        focused
+      }
+      val target = Json.parseToJsonElement(js(scenario, """
+        (() => { const r = document.getElementById('boardTitle').getBoundingClientRect();
+          return { x: r.left + r.width / 2, y: r.top + r.height / 2, width: innerWidth }; })()
+      """.trimIndent())).jsonObject
+      var x = 0f
+      var y = 0f
       scenario.onActivity { activity ->
-        activity.web.requestFocus()
+        val origin = IntArray(2)
+        activity.web.getLocationOnScreen(origin)
+        val scale = activity.web.width / target.getValue("width").jsonPrimitive.float
+        x = origin[0] + target.getValue("x").jsonPrimitive.float * scale
+        y = origin[1] + target.getValue("y").jsonPrimitive.float * scale
+      }
+      // A real tap establishes the WebView input connection. JS focus alone
+      // can race IME startup, especially just after an orientation change.
+      val down = SystemClock.uptimeMillis()
+      for (action in listOf(MotionEvent.ACTION_DOWN, MotionEvent.ACTION_UP)) {
+        val event = MotionEvent.obtain(down, SystemClock.uptimeMillis(), action, x, y, 0)
+        InstrumentationRegistry.getInstrumentation().sendPointerSync(event)
+        event.recycle()
+      }
+      until("Board title did not receive the tap") { js(scenario, "document.activeElement.id === 'boardTitle'") == "true" }
+      scenario.onActivity { activity ->
         WindowCompat.getInsetsController(activity.window, activity.web).show(WindowInsetsCompat.Type.ime())
       }
       until("Keyboard did not open") { keyboardVisible(scenario) }
       until("Editor did not resize above the keyboard") {
         layout(scenario).getValue("height").jsonPrimitive.double < before.getValue("height").jsonPrimitive.double - 80
       }
-      until("Zoom must stay compact and visible above the keyboard") { js(scenario, """
-        (() => {
-          const zoom = document.getElementById('zoombar');
-          const box = zoom.getBoundingClientRect();
-          return box.height > 0 && box.height < 70 && box.top >= 0 && box.bottom <= innerHeight
-            && (!matchMedia('(max-height: 460px)').matches || getComputedStyle(zoom).bottom === 'auto');
-        })()
-      """.trimIndent()) == "true" }
+      try {
+        until("Zoom must stay compact and visible above the keyboard") { js(scenario, """
+          (() => {
+            const zoom = document.getElementById('zoombar');
+            const box = zoom.getBoundingClientRect();
+            return box.height > 0 && box.height < 70 && box.top >= 0 && box.bottom <= innerHeight;
+          })()
+        """.trimIndent()) == "true" }
+      } catch (error: AssertionError) {
+        throw AssertionError(error.message + "; " + js(scenario, """
+          JSON.stringify({ viewport: [innerWidth, innerHeight], focus: document.activeElement.id,
+            coarse: matchMedia('(pointer: coarse)').matches,
+            zoom: document.getElementById('zoombar').getBoundingClientRect().toJSON() })
+        """.trimIndent()))
+      }
       js(scenario, "document.getElementById('boardTitle').blur();")
       scenario.onActivity { WindowCompat.getInsetsController(it.window, it.web).hide(WindowInsetsCompat.Type.ime()) }
       until("Keyboard did not close") { !keyboardVisible(scenario) }

--- a/android/app/src/androidTest/java/com/gazboard/app/InsetsTest.kt
+++ b/android/app/src/androidTest/java/com/gazboard/app/InsetsTest.kt
@@ -124,6 +124,14 @@ class InsetsTest {
       until("Editor did not resize above the keyboard") {
         layout(scenario).getValue("height").jsonPrimitive.double < before.getValue("height").jsonPrimitive.double - 80
       }
+      until("Zoom must stay compact and visible above the keyboard") { js(scenario, """
+        (() => {
+          const zoom = document.getElementById('zoombar');
+          const box = zoom.getBoundingClientRect();
+          return box.height > 0 && box.height < 70 && box.top >= 0 && box.bottom <= innerHeight
+            && (!matchMedia('(max-height: 460px)').matches || getComputedStyle(zoom).bottom === 'auto');
+        })()
+      """.trimIndent()) == "true" }
       js(scenario, "document.getElementById('boardTitle').blur();")
       scenario.onActivity { WindowCompat.getInsetsController(it.window, it.web).hide(WindowInsetsCompat.Type.ime()) }
       until("Keyboard did not close") { !keyboardVisible(scenario) }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,14 @@
         <data android:mimeType="application/json" />
         <data android:mimeType="application/pdf" />
       </intent-filter>
+      <!-- File managers commonly label custom extensions as binary data.
+           Content URIs may contain only an ID, so a filename path filter
+           would miss boards even when DISPLAY_NAME ends in .gazboard. -->
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:scheme="content" android:mimeType="application/octet-stream" />
+      </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.SEND" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/android/app/src/main/java/com/gazboard/app/MainActivity.kt
+++ b/android/app/src/main/java/com/gazboard/app/MainActivity.kt
@@ -176,7 +176,8 @@ class MainActivity : ComponentActivity() {
       saving = save
       val extensions = (options["filters"] as? JsonArray)?.firstOrNull()?.obj()?.get("extensions") as? JsonArray
       val types = extensions?.mapNotNull { MimeTypeMap.getSingleton().getMimeTypeFromExtension(it.jsonPrimitive.content) }?.distinct() ?: emptyList()
-      val mime = if (types.size == 1) types[0] else "*/*"
+      val boardExport = save && options.str("defaultPath").substringAfterLast('.').lowercase() in listOf("gazboard", "openboard")
+      val mime = if (boardExport) "application/x-gazboard" else if (types.size == 1) types[0] else "*/*"
       val intent = Intent(if (save) Intent.ACTION_CREATE_DOCUMENT else Intent.ACTION_OPEN_DOCUMENT).apply {
         addCategory(Intent.CATEGORY_OPENABLE)
         type = mime

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -557,22 +557,13 @@ kbd {
 }
 
 /*
- * ...unless the keyboard has taken the bottom.
- *
- * The rule above pins the readouts above the pen tray, which is right until
- * there is no bottom left to sit above: with the on-screen keyboard open the
- * viewport is half as tall and 98px from the bottom is underneath it. The
- * short-screen rule that moves them to the top used to cover this and was
- * narrowed to `pointer: fine`, which excludes every phone - the one kind of
- * screen that HAS an on-screen keyboard.
- *
- * This has to come after the block above, and it has to set `bottom: auto`.
- * A box given both a top and a bottom does not move, it stretches, and that is
- * how the zoom readout once became a 276-pixel white column down the side.
+ * A short screen can be landscape or a keyboard-reduced viewport. Only move
+ * the readouts up while editing text; landscape alone keeps them by the pens.
+ * Clear the opposite edge so the controls cannot stretch into a tall column.
  */
 @media (pointer: coarse) and (max-height: 460px) {
-  #zoombar { top: 8px; bottom: auto; }
-  #pagebar { top: 52px; bottom: auto; }
+  body.typing #zoombar, body:has(#boardTitle:focus) #zoombar { top: 8px; bottom: auto; }
+  body.typing #pagebar, body:has(#boardTitle:focus) #pagebar { top: 52px; bottom: auto; }
 }
 
 /* Smartphone portrait viewports (under 480px width) */

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1829,11 +1829,15 @@ class App {
   /** Consent first if it has never been given, otherwise a quiet daily look. */
   async startUpdateFlow() {
     try {
-      if ((await this.appInfo())?.smoke) return;
-      this.showHint('panning',
-        'Moving around: drag with the <b>middle mouse button</b>, hold <b>Space</b> and drag, '
-        + 'or pick the <b>Pan</b> tool (<b>G</b>) from the toolbar. The right button drags too, '
-        + 'and the scroll wheel works as usual.');
+      const info = await this.appInfo();
+      if (info?.smoke) return;
+      // Android has its own finger gestures; desktop shortcuts do not help on first launch.
+      if (!info?.isAndroid) {
+        this.showHint('panning',
+          'Moving around: drag with the <b>middle mouse button</b>, hold <b>Space</b> and drag, '
+          + 'or pick the <b>Pan</b> tool (<b>G</b>) from the toolbar. The right button drags too, '
+          + 'and the scroll wheel works as usual.');
+      }
       if (this.settings.updateCheck === null || this.settings.updateCheck === undefined) {
         // Dismissing the question means "not now", and not now should last
         // longer than one launch. It used to come back every single time the app

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1831,8 +1831,15 @@ class App {
     try {
       const info = await this.appInfo();
       if (info?.smoke) return;
-      // Android has its own finger gestures; desktop shortcuts do not help on first launch.
-      if (!info?.isAndroid) {
+      if (info?.isAndroid) {
+        const finger = this.fingerInks ? 'Your <b>finger</b> draws too. ' : 'One <b>finger</b> moves the board. ';
+        const mouse = typeof matchMedia === 'function' && matchMedia('(any-pointer: fine)').matches
+          ? (this.mouseInks ? 'A connected <b>mouse</b> draws too. ' : 'A connected <b>mouse</b> moves the board. ') : '';
+        this.showHint('android-navigation',
+          'Move with <b>two fingers</b>; <b>pinch</b> to zoom. With <b>Pen</b> selected, draw with a <b>stylus</b>. '
+          + finger + mouse + 'Hold an object to select it; tap <b>…</b> for more actions. '
+          + 'Change drawing controls in <b>Settings</b>.');
+      } else {
         this.showHint('panning',
           'Moving around: drag with the <b>middle mouse button</b>, hold <b>Space</b> and drag, '
           + 'or pick the <b>Pan</b> tool (<b>G</b>) from the toolbar. The right button drags too, '
@@ -2111,6 +2118,9 @@ class App {
           this.boardOpenedExplicitly = true;
           const data = JSON.parse(new TextDecoder().decode(await window.board.readFile(path)));
           data.origin = window.board.fileOrigin(path);
+          // Opening another file must not discard edits in the current board.
+          this.commitTextEdit();
+          await this.persist();
           await this.loadBoard(data, { asCopy: false });
         } else if (isImagePath(path)) await insertImagesFromPaths(this, [path]);
         else if (isDocPath(path)) await insertDocument(this, path);

--- a/src/js/core/tools.js
+++ b/src/js/core/tools.js
@@ -727,7 +727,7 @@ export class Interaction {
   /**
    * Start the clock on a press-and-hold, if this could be one.
    *
-   * A finger or stylus can select an object without leaving the ink tool.
+   * A finger can select an object without leaving the ink tool.
    * This also covers a finger set to pan, where touching an object begins
    * a transient move. A quick tap or a stroke keeps its usual meaning.
    */

--- a/src/js/core/tools.js
+++ b/src/js/core/tools.js
@@ -81,6 +81,9 @@ export class Interaction {
     c.addEventListener('dblclick', (e) => this.onDoubleClick(e));
     c.addEventListener('contextmenu', (e) => {
       e.preventDefault();
+      // Android opens expanded actions from the selection bar's More button.
+      // Its native long-press event can arrive even after the pointer lifts.
+      if (document.documentElement?.dataset.platform === 'android') return;
       /*
        * A right-click idea, on a device with no right button.
        *
@@ -760,7 +763,7 @@ export class Interaction {
       else if (!this.startMoveOnSelection(wp)) { this.actionId = null; return; }
       this.actionId = this._holdId;
       this.action.holdMenu = true;
-      this.app.showContextMenu(e);
+      if (document.documentElement?.dataset.platform !== 'android') this.app.showContextMenu(e);
       // A hidden gesture nobody is told about is a gesture nobody uses.
       this.app.toast(hit.locked ? 'Locked — choose Unlock to resize or move' : 'Selected — drag a handle to resize', 'check', 1400);
       this.surface.invalidate();

--- a/src/js/core/tools.js
+++ b/src/js/core/tools.js
@@ -621,7 +621,7 @@ export class Interaction {
         return;
       }
     }
-    this.cancelHold();
+    if (e.pointerId === this._holdId) this.cancelHold();
     this.pointers.delete(e.pointerId);
     if (this.secondaryPan && e.pointerId === this.secondaryPan.id) { this.secondaryPan = null; return; }
     if (this.pinch) { if (this.pointers.size < 2) this.pinch = null; return; }
@@ -727,21 +727,13 @@ export class Interaction {
   /**
    * Start the clock on a press-and-hold, if this could be one.
    *
-   * A finger can select an object without leaving the ink tool.
+   * A finger or stylus can select an object without leaving the ink tool.
    * This also covers a finger set to pan, where touching an object begins
    * a transient move. A quick tap or a stroke keeps its usual meaning.
    */
   armHoldToMove(e, sp, wp) {
     this.cancelHold();
-    /*
-     * Fingers only. A stylus held still over an object is somebody lining up
-     * the first mark of a letter, not asking to pick the object up - and
-     * stealing that pause turns their handwriting into a drag. A pen has the
-     * Select tool a tap away and does not lose its place reaching for it,
-     * which is the whole reason this gesture exists for a finger and not for
-     * a pen. Arming it for both put the two cases back in competition.
-     */
-    if (e.pointerType !== 'touch') return;
+    if (e.pointerType !== 'touch' && e.pointerType !== 'pen') return;
     const eligible = () => this.action && (this.action.type === 'draw' || this.action.type === 'pan'
       || (this.action.type === 'move' && this.action.transient));
     // A drawing finger, or a panning one. Once the finger stopped drawing and

--- a/src/js/ui/contextmenu.js
+++ b/src/js/ui/contextmenu.js
@@ -14,12 +14,12 @@ function item(label, iconName, onClick, opts = {}) {
   return b;
 }
 
-export function showContextMenu(app, e) {
+export function showContextMenu(app, e, fromSelectionBar = false) {
   const sel = app.surface.selection;
   const wp = app.surface.toWorld(e);
 
   // right-clicking an unselected object selects it first
-  const hit = app.pickAt(wp);
+  const hit = fromSelectionBar ? null : app.pickAt(wp);
   if (hit && !sel.has(hit.id)) app.setSelection([hit.id]);
 
   const has = app.surface.selection.size > 0;
@@ -95,6 +95,7 @@ export function updateSelectionBar(app) {
     unlock.style.display = 'flex';
     unlock.style.alignItems = 'center';
     bar.appendChild(unlock);
+    appendMoreActions(app, bar);
     placeBar(bar, box);
     return;
   }
@@ -141,19 +142,22 @@ export function updateSelectionBar(app) {
   bar.appendChild(mk(sel.every((o) => o.locked) ? 'Unlock' : 'Lock', sel.every((o) => o.locked) ? 'unlock' : 'lock', () => app.command('edit.lock')));
   bar.appendChild(mk('Delete (Del)', 'trash', () => app.command('edit.delete')));
 
-  /*
-   * On a touch device the long press means "pick this up", so the menu it used
-   * to open has to arrive some other way. A visible button beats a hidden
-   * gesture anyway - nobody has ever discovered a long press by looking.
-   */
-  if (typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches) {
-    bar.appendChild(mk('More actions', 'more', () => {
-      const r = bar.getBoundingClientRect();
-      showContextMenu(app, { clientX: r.left + r.width - 12, clientY: r.bottom + 4 });
-    }));
-  }
+  appendMoreActions(app, bar);
 
   placeBar(bar, box);
+}
+
+function appendMoreActions(app, bar) {
+  // Android still needs this route when a mouse changes the primary pointer.
+  if (document.documentElement?.dataset.platform !== 'android'
+      && !(typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches)) return;
+  const button = h('button', { title: 'More actions', html: icon('more', 17) });
+  button.addEventListener('click', () => {
+    const r = bar.getBoundingClientRect();
+    // This button acts on the selection, not an object behind the toolbar.
+    showContextMenu(app, { clientX: r.left + r.width - 12, clientY: r.bottom + 4 }, true);
+  });
+  bar.appendChild(button);
 }
 
 function placeBar(bar, box) {

--- a/test/android-selection.test.js
+++ b/test/android-selection.test.js
@@ -161,7 +161,7 @@ test('A handle survives committing an active text edit and owns the resize', asy
   assert.equal(store.get('selected').h, 140);
 });
 
-for (const [type, fingerInks] of [['touch', true], ['touch', false], ['pen', true]]) {
+for (const [type, fingerInks] of [['touch', true], ['touch', false]]) {
   test(`Holding ${type}, finger ink ${fingerInks}, opens object actions while keeping the pen`, async (t) => {
     const { app, interaction, pointer, store, surface } = await setup({ fingerInks });
     surface.selection.clear();
@@ -175,6 +175,34 @@ for (const [type, fingerInks] of [['touch', true], ['touch', false], ['pen', tru
     interaction.onUp(pointer(type, 150, 150, 0));
     assert.equal(store.count, before);
     assert.deepEqual([...surface.selection], ['selected']);
+    assert.equal(surface.wet, null);
+  });
+}
+
+for (const tool of ['pen', 'highlighter']) for (const fingerInks of [true, false]) {
+  test(`A paused stylus resumes ${tool} ink without selecting the note (finger ink ${fingerInks})`, async (t) => {
+    const { app, interaction, pointer, store, surface } = await setup({ tool, fingerInks });
+    surface.selection.clear();
+    const before = store.count, undo = store.undoStack.length;
+    const note = structuredClone(store.get('selected'));
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    interaction.onDown(pointer('pen', 150, 150));
+    t.mock.timers.tick(1000);           // well beyond the finger's hold threshold
+    assert.notEqual(app.menuShown, true);
+    assert.equal(app.tool, tool);
+    assert.equal(interaction.action.type, 'draw');
+    assert.ok(surface.wet);
+    assert.equal(surface.selection.size, 0);
+    interaction.applyMotion({ x: 170, y: 165 });
+    interaction.onUp(pointer('pen', 170, 165, 0));
+    assert.equal(store.count, before + 1);
+    assert.equal(store.undoStack.length, undo + 1);
+    const stroke = store.objects.at(-1);
+    assert.equal(stroke.type, 'stroke');
+    assert.equal(stroke.tool, tool);
+    assert.ok(stroke.points.length > 1 && stroke.bbox.w > 4);
+    assert.deepEqual(store.get('selected'), note);
+    assert.equal(surface.selection.size, 0);
     assert.equal(surface.wet, null);
   });
 }

--- a/test/android-selection.test.js
+++ b/test/android-selection.test.js
@@ -5,7 +5,8 @@ const assert = require('node:assert/strict');
 // These fixtures use notes and strokes, whose hit tests use geometry only.
 global.document = { createElement: () => ({ getContext: () => ({}) }) };
 
-async function setup({ tool = 'pen', z = 1, editing = false, fingerInks = true } = {}) {
+async function setup({ tool = 'pen', z = 1, editing = false, fingerInks = true, android = false } = {}) {
+  document.documentElement = { dataset: { platform: android ? 'android' : 'electron' } };
   const [{ Interaction }, { Store, boundsOf }, { Camera }, { unionBox }] = await Promise.all([
     import('../src/js/core/tools.js'), import('../src/js/core/store.js'),
     import('../src/js/core/camera.js'), import('../src/js/core/util.js')
@@ -18,7 +19,7 @@ async function setup({ tool = 'pen', z = 1, editing = false, fingerInks = true }
   const cam = new Camera();
   cam.z = z;
   const surface = {
-    canvas: { addEventListener() {}, setPointerCapture() {} },
+    canvas: { listeners: {}, addEventListener(name, handler) { this.listeners[name] = handler; }, setPointerCapture() {} },
     cam, w: 2000, h: 2000, overlays: [], selection: new Set(['selected']), wet: null,
     screenPoint: (e) => ({ x: e.clientX, y: e.clientY }),
     selectionBounds: () => [...surface.selection].reduce((b, id) => unionBox(b, boundsOf(store.get(id))), null),
@@ -161,15 +162,15 @@ test('A handle survives committing an active text edit and owns the resize', asy
   assert.equal(store.get('selected').h, 140);
 });
 
-for (const type of ['touch', 'pen']) for (const fingerInks of [true, false]) {
-  test(`Holding ${type}, finger ink ${fingerInks}, opens object actions while keeping the pen`, async (t) => {
-    const { app, interaction, pointer, store, surface } = await setup({ fingerInks });
+for (const android of [false, true]) for (const type of ['touch', 'pen']) for (const fingerInks of [true, false]) {
+  test(`Holding ${type}, finger ink ${fingerInks}, selects with Android ${android} menu behavior`, async (t) => {
+    const { app, interaction, pointer, store, surface } = await setup({ fingerInks, android });
     surface.selection.clear();
     t.mock.timers.enable({ apis: ['setTimeout'] });
     const before = store.count, undo = store.undoStack.length;
     interaction.onDown(pointer(type, 150, 150));
     t.mock.timers.tick(451);
-    assert.equal(app.menuShown, true);
+    assert.equal(!!app.menuShown, !android);
     assert.equal(app.tool, 'pen');
     assert.equal(interaction.action.type, 'move');
     interaction.onUp(pointer(type, 150, 150, 0));
@@ -223,3 +224,15 @@ test('A palm lifting does not cancel the stylus hold selection', async (t) => {
   assert.equal(store.count, before);
   assert.equal(surface.wet, null);
 });
+
+for (const type of ['touch', 'pen', 'mouse']) {
+  test(`Android suppresses the delayed ${type} context menu after release`, async () => {
+    const { app, interaction, surface } = await setup({ android: true });
+    interaction._lastDownType = type;
+    interaction.action = null;
+    let prevented = false;
+    surface.canvas.listeners.contextmenu({ preventDefault() { prevented = true; } });
+    assert.equal(prevented, true);
+    assert.notEqual(app.menuShown, true);
+  });
+}

--- a/test/android-selection.test.js
+++ b/test/android-selection.test.js
@@ -161,12 +161,12 @@ test('A handle survives committing an active text edit and owns the resize', asy
   assert.equal(store.get('selected').h, 140);
 });
 
-for (const [type, fingerInks] of [['touch', true], ['touch', false]]) {
+for (const type of ['touch', 'pen']) for (const fingerInks of [true, false]) {
   test(`Holding ${type}, finger ink ${fingerInks}, opens object actions while keeping the pen`, async (t) => {
     const { app, interaction, pointer, store, surface } = await setup({ fingerInks });
     surface.selection.clear();
     t.mock.timers.enable({ apis: ['setTimeout'] });
-    const before = store.count;
+    const before = store.count, undo = store.undoStack.length;
     interaction.onDown(pointer(type, 150, 150));
     t.mock.timers.tick(451);
     assert.equal(app.menuShown, true);
@@ -174,26 +174,27 @@ for (const [type, fingerInks] of [['touch', true], ['touch', false]]) {
     assert.equal(interaction.action.type, 'move');
     interaction.onUp(pointer(type, 150, 150, 0));
     assert.equal(store.count, before);
+    assert.equal(store.undoStack.length, undo);
     assert.deepEqual([...surface.selection], ['selected']);
     assert.equal(surface.wet, null);
   });
 }
 
 for (const tool of ['pen', 'highlighter']) for (const fingerInks of [true, false]) {
-  test(`A paused stylus resumes ${tool} ink without selecting the note (finger ink ${fingerInks})`, async (t) => {
+  test(`Moving the stylus cancels hold selection during ${tool} ink (finger ink ${fingerInks})`, async (t) => {
     const { app, interaction, pointer, store, surface } = await setup({ tool, fingerInks });
     surface.selection.clear();
     const before = store.count, undo = store.undoStack.length;
     const note = structuredClone(store.get('selected'));
     t.mock.timers.enable({ apis: ['setTimeout'] });
     interaction.onDown(pointer('pen', 150, 150));
-    t.mock.timers.tick(1000);           // well beyond the finger's hold threshold
+    interaction.onMove(pointer('pen', 170, 165));
+    t.mock.timers.tick(1000);           // pausing mid-stroke must not select
     assert.notEqual(app.menuShown, true);
     assert.equal(app.tool, tool);
     assert.equal(interaction.action.type, 'draw');
     assert.ok(surface.wet);
     assert.equal(surface.selection.size, 0);
-    interaction.applyMotion({ x: 170, y: 165 });
     interaction.onUp(pointer('pen', 170, 165, 0));
     assert.equal(store.count, before + 1);
     assert.equal(store.undoStack.length, undo + 1);
@@ -206,3 +207,19 @@ for (const tool of ['pen', 'highlighter']) for (const fingerInks of [true, false
     assert.equal(surface.wet, null);
   });
 }
+
+test('A palm lifting does not cancel the stylus hold selection', async (t) => {
+  const { app, interaction, pointer, store, surface } = await setup();
+  surface.selection.clear();
+  const before = store.count;
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  interaction.onDown(pointer('pen', 150, 150));
+  interaction.onDown({ ...pointer('touch', 500, 300), pointerId: 2 });
+  interaction.onUp({ ...pointer('touch', 500, 300, 0), pointerId: 2 });
+  t.mock.timers.tick(451);
+  assert.equal(app.menuShown, true);
+  assert.deepEqual([...surface.selection], ['selected']);
+  interaction.onUp(pointer('pen', 150, 150, 0));
+  assert.equal(store.count, before);
+  assert.equal(surface.wet, null);
+});


### PR DESCRIPTION
Android should open exported boards from the file manager and explain touch controls on first use. Holding an object should keep it available to drag or resize, with expanded actions behind the quick toolbar's three-dot button.

This PR:
- Accepts generic binary content URIs used by file managers for .gazboard files, including opaque document-provider URIs. The importer checks the displayed filename and reports unsupported formats. New board exports request application/x-gazboard.
- Saves current edits before opening another board.
- Adds a one-time Android startup tip in the existing style: two-finger pan, pinch zoom, stylus drawing, finger behavior based on settings, and mouse guidance when a precise pointer is available.
- Restores finger/stylus hold selection while Pen stays active, preserves drag/resize after a palm lifts, and prevents delayed Android context-menu events from opening expanded actions.
- Keeps More available for locked objects and attached mice without changing the selection.
- Positions landscape zoom near the toolbar, moving it up during text editing on short screens.

No new dependencies or storage permissions. Android cannot filter an opaque content URI by the provider's display filename, so the generic binary association can also offer GazBoard for unsupported binary files; these receive the existing unsupported-format message.

Validation for c8600d4:
- JavaScript syntax and all 43 local editor checks passed.
- Android build and lint passed.
- Phone and tablet device tests are running, including new file-opening and startup-tip coverage.

[Latest workflow](https://github.com/fahim9778/GazBoard/actions/runs/34439371182)
[Android APK artifact](https://github.com/fahim9778/GazBoard/actions/runs/34439371182/artifacts/10137410030)

Earlier validation: the 10 existing device tests passed on both emulators for 2cdf83f. That run's phone save/reopen test needed one retry; this PR does not claim to fix that intermittent test failure.